### PR TITLE
Issue #11 - ErrorDecodingError constant not used

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -65,7 +65,7 @@ func (c *client) Do(ctx context.Context, method string, slug string, query url.V
 		prob := glitch.HTTPProblem{}
 		err := json.Unmarshal(ret, &prob)
 		if err != nil {
-			return glitch.NewDataError(err, ErrorRequestError, "Could not decode error response")
+			return glitch.NewDataError(err, ErrorDecodingError, "Could not decode error response")
 		}
 		return glitch.FromHTTPProblem(prob, fmt.Sprintf("Error from %s to %s - %s", method, c.serviceName, slug))
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -142,7 +142,7 @@ func TestUnit_Do(t *testing.T) {
 				u, err := url.Parse(testServer.URL)
 				return *u, err
 			},
-			expectedErr: glitch.NewDataError(nil, "ERROR_MAKING_REQUEST", "Could not decode error response"),
+			expectedErr: glitch.NewDataError(nil, ErrorDecodingError, "Could not decode error response"),
 			validate: func(t *testing.T, expectedResponse, actualResponse interface{}, expectedErr, actualErr glitch.DataError) {
 				require.Error(t, actualErr)
 				require.Equal(t, expectedErr.Code(), actualErr.Code())
@@ -160,7 +160,7 @@ func TestUnit_Do(t *testing.T) {
 				u, err := url.Parse(testServer.URL)
 				return *u, err
 			},
-			expectedErr: glitch.NewDataError(nil, "ERROR_DECODING_RESPONSE", "Could not decode response"),
+			expectedErr: glitch.NewDataError(nil, ErrorDecodingResponse, "Could not decode response"),
 			validate: func(t *testing.T, expectedResponse, actualResponse interface{}, expectedErr, actualErr glitch.DataError) {
 				require.Error(t, actualErr)
 				require.Equal(t, expectedErr.Code(), actualErr.Code())
@@ -178,7 +178,7 @@ func TestUnit_Do(t *testing.T) {
 				u, _ := url.Parse(testServer.URL)
 				return *u, errors.New("error finding service")
 			},
-			expectedErr: glitch.NewDataError(errors.New("error finding service"), "CANT_FIND_SERVICE", "Error finding service"),
+			expectedErr: glitch.NewDataError(errors.New("error finding service"), ErrorCantFind, "Error finding service"),
 			validate: func(t *testing.T, expectedResponse, actualResponse interface{}, expectedErr, actualErr glitch.DataError) {
 				require.Error(t, actualErr)
 				require.Equal(t, expectedErr, actualErr)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/sprak3000/go-glitch v0.0.0-20170714151522-c1136cd4a72e
+	github.com/sprak3000/go-glitch v1.0.1
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,11 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sprak3000/go-glitch v0.0.0-20170714151522-c1136cd4a72e h1:HjZawPGJ8T8736jeOGVn9I98Hy/qgKOOlGNSV/8cOLA=
-github.com/sprak3000/go-glitch v0.0.0-20170714151522-c1136cd4a72e/go.mod h1:AnVgMehzzQZ3tM72E460d6e4AbSa+d5DVTTgQCUmy1g=
+github.com/sprak3000/go-glitch v1.0.1 h1:fI5HjMmib3jq/9p/ccL1d+CtdP20Xc7QUTlNUpty5GI=
+github.com/sprak3000/go-glitch v1.0.1/go.mod h1:gAghf5TnJBpx+SwVPviNhUD7qeeqBy8hB1W7V+z/wrU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
- Use the constant in the error returned when it cannot unmarshal the problem response.
- Vendor in the now tagged version of `go-glitch`.

Closes #11.